### PR TITLE
Replace Monero branding in config files

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Monero"
+PROJECT_NAME           = "NetCodex"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/cmake/Doxyfile.in
+++ b/cmake/Doxyfile.in
@@ -26,7 +26,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need 
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = Monero
+PROJECT_NAME           = NetCodex
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. 
 # This could be handy for archiving the generated documentation or 

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -27,7 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 function (write_version tag)
-  set(VERSIONTAG "${tag}" CACHE STRING "The tag portion of the Monero software version" FORCE)
+  set(VERSIONTAG "${tag}" CACHE STRING "The tag portion of the NetCodex software version" FORCE)
   configure_file("${CMAKE_CURRENT_LIST_DIR}/../src/version.cpp.in" "${CMAKE_BINARY_DIR}/version.cpp")
 endfunction ()
 

--- a/utils/systemd/netcodexd.service
+++ b/utils/systemd/netcodexd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Monero Full Node
+Description=NetCodex Full Node
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
## Summary
- update Doxyfile PROJECT_NAME to NetCodex
- update cmake Doxyfile template with NetCodex
- update systemd service description
- adjust cmake version description string

## Testing
- `ctest` *(fails: No test configuration file found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685cd447d3b08332a23224691988c13e