### PR TITLE
Update money supply constant

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -51,7 +51,7 @@
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
 
 // MONEY_SUPPLY - total number coins to be generated
-#define MONEY_SUPPLY                                    ((uint64_t)(-1))
+#define MONEY_SUPPLY                                    ((uint64_t)41000000000)
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)300000000000) // 3 * pow(10, 11)
 


### PR DESCRIPTION
## Summary
- tweak the cryptonote configuration to set a fixed money supply value

## Testing
- `make -j2 release-test` *(fails: Submodule 'external/miniupnp' is not up-to-date)*
- `git submodule update --init --recursive` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_685e186ed66c83329805348515c7e1b2