### PR TITLE
Rename coin to netcodex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,12 +43,12 @@ COPY --from=builder /src/build/x86_64-linux-gnu/release/bin /usr/local/bin/
 
 # Create monero user
 RUN adduser --system --group --disabled-password monero && \
-	mkdir -p /wallet /home/monero/.bitmonero && \
-	chown -R monero:monero /home/monero/.bitmonero && \
+	mkdir -p /wallet /home/monero/.netcodex && \
+	chown -R monero:monero /home/monero/.netcodex && \
 	chown -R monero:monero /wallet
 
 # Contains the blockchain
-VOLUME /home/monero/.bitmonero
+VOLUME /home/monero/.netcodex
 
 # Generate your wallet via accessing the container and run:
 # cd /wallet

--- a/README.md
+++ b/README.md
@@ -575,10 +575,10 @@ More info and versions in the [Debian package tracker](https://tracker.debian.or
     docker build --build-arg NPROC=1 -t monero .
 
     # either run in foreground
-    docker run -it -v /monero/chain:/home/monero/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
+    docker run -it -v /monero/chain:/home/monero/.netcodex -v /monero/wallet:/wallet -p 18080:18080 monero
 
     # or in background
-    docker run -it -d -v /monero/chain:/home/monero/.bitmonero -v /monero/wallet:/wallet -p 18080:18080 monero
+    docker run -it -d -v /monero/chain:/home/monero/.netcodex -v /monero/wallet:/wallet -p 18080:18080 monero
     ```
 
 * The build needs 3 GB space.

--- a/contrib/tor/netcodex-over-tor.sh
+++ b/contrib/tor/netcodex-over-tor.sh
@@ -86,7 +86,7 @@ done
 if test "$ready" = 0
 then
   echo "Error starting monerod"
-  tail -n 400 "$HOME/.bitmonero/bitmonero.log" | grep -Ev stacktrace\|"Error: Couldn't connect to daemon:"\|"src/daemon/main.cpp:.*Monero\ \'" | tail -n 20
+  tail -n 400 "$HOME/.netcodex/netcodex.log" | grep -Ev stacktrace\|"Error: Couldn't connect to daemon:"\|"src/daemon/main.cpp:.*Monero\ \'" | tail -n 20
   exit 1
 fi
 

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -130,7 +130,7 @@ static bool parse_db_sync_mode(std::string db_sync_mode)
 static std::string get_default_db_path()
 {
   boost::filesystem::path dir = tools::get_default_data_dir();
-  // remove .bitmonero, replace with .shared-ringdb
+  // remove .netcodex, replace with .shared-ringdb
   dir = dir.remove_filename();
   dir /= ".shared-ringdb";
   return dir.string();

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -162,7 +162,8 @@
 
 #define RPC_IP_FAILS_BEFORE_BLOCK                       3
 
-#define CRYPTONOTE_NAME                         "bitmonero"
+#define CRYPTONOTE_NAME                         "netcodex"
+#define CRYPTONOTE_TICKER                       "NCD"
 #define CRYPTONOTE_BLOCKCHAINDATA_FILENAME      "data.mdb"
 #define CRYPTONOTE_BLOCKCHAINDATA_LOCK_FILENAME "lock.mdb"
 #define P2P_NET_DATA_FILENAME                   "p2pstate.bin"

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -248,7 +248,7 @@ int main(int argc, char const * argv[])
     }
 
     // data_dir
-    //   default: e.g. ~/.bitmonero/ or ~/.bitmonero/testnet
+    //   default: e.g. ~/.netcodex/ or ~/.netcodex/testnet
     //   if data-dir argument given:
     //     absolute path
     //     relative path: relative to cwd

--- a/src/daemonizer/posix_fork.cpp
+++ b/src/daemonizer/posix_fork.cpp
@@ -120,7 +120,7 @@ void fork(const std::string & pidfile)
   if (!tmpdir)
     tmpdir = TMPDIR;
   std::string output = tmpdir;
-  output += "/bitmonero.daemon.stdout.stderr";
+  output += "/netcodex.daemon.stdout.stderr";
   const int flags = O_WRONLY | O_CREAT | O_APPEND;
   const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
   if (open(output.c_str(), flags, mode) < 0)

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -107,7 +107,7 @@ namespace {
     std::string get_default_ringdb_path(cryptonote::network_type nettype)
     {
       boost::filesystem::path dir = tools::get_default_data_dir();
-      // remove .bitmonero, replace with .shared-ringdb
+      // remove .netcodex, replace with .shared-ringdb
       dir = dir.remove_filename();
       dir /= ".shared-ringdb";
       if (nettype == cryptonote::TESTNET)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -166,7 +166,7 @@ namespace
   std::string get_default_ringdb_path()
   {
     boost::filesystem::path dir = tools::get_default_data_dir();
-    // remove .bitmonero, replace with .shared-ringdb
+    // remove .netcodex, replace with .shared-ringdb
     dir = dir.remove_filename();
     dir /= ".shared-ringdb";
     return dir.string();


### PR DESCRIPTION
## Summary
- rename `CRYPTONOTE_NAME` to "netcodex"
- add a coin ticker macro
- update Dockerfile, README, scripts, and comments to use `.netcodex` paths
- rename daemon log path in `posix_fork.cpp`

## Testing
- `git submodule update --init --force` *(fails: CONNECT tunnel failed)*
- `cmake ..` *(fails: Submodule 'external/miniupnp' is not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_685e1877934083328614d8b101c923cd