### PR TITLE
Add staking fields to block header

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -488,6 +488,8 @@ namespace cryptonote
     uint64_t timestamp;
     crypto::hash  prev_id;
     uint32_t nonce;
+    crypto::public_key stake_key;
+    crypto::signature stake_signature;
 
     BEGIN_SERIALIZE()
       VARINT_FIELD(major_version)
@@ -495,6 +497,8 @@ namespace cryptonote
       VARINT_FIELD(timestamp)
       FIELD(prev_id)
       FIELD(nonce)
+      FIELD(stake_key)
+      FIELD(stake_signature)
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1615,6 +1615,8 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     }
   }
   b.timestamp = time(NULL);
+  b.stake_key = crypto::null_pkey;
+  b.stake_signature = crypto::signature();
 
   uint64_t median_ts;
   if (!check_block_timestamp(b, median_ts))


### PR DESCRIPTION
## Summary
- extend `block_header` with `stake_key` and `stake_signature`
- initialize the new staking fields when creating block templates

## Testing
- `make release-test` *(fails: submodules not up to date)*

------
https://chatgpt.com/codex/tasks/task_e_685e1a811a8883328e96cdde6f6361c5