### PR TITLE
Add staking validation

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -66,6 +66,11 @@
 // COIN - number of smallest units in one coin
 #define COIN                                            ((uint64_t)1000000000000) // pow(10, 12)
 
+// minimum amount required to participate in staking (1 NCD)
+#define STAKE_MIN_AMOUNT                                ((uint64_t)COIN)
+// number of blocks coins must remain untouched before they can be staked
+#define STAKE_MATURITY_BLOCKS                           10
+
 #define FEE_PER_KB_OLD                                  ((uint64_t)10000000000) // pow(10, 10)
 #define FEE_PER_KB                                      ((uint64_t)2000000000) // 2 * pow(10, 9)
 #define FEE_PER_BYTE                                    ((uint64_t)300000)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2304,6 +2304,12 @@ bool Blockchain::verify_stake_signature(const block& bl, const crypto::hash& id)
     return false;
   }
 
+  if (!has_mature_unspent_stake(pub_key))
+  {
+    MWARNING("Staking key does not have a mature stake for block " << id);
+    return false;
+  }
+
   return true;
 }
 
@@ -2357,6 +2363,35 @@ bool Blockchain::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMA
     return false;
   }
   return true;
+}
+//------------------------------------------------------------------
+bool Blockchain::has_mature_unspent_stake(const crypto::public_key &stake_key) const
+{
+  LOG_PRINT_L3("Blockchain::" << __func__);
+  const uint64_t current_height = m_db->height();
+  const uint8_t hf_version = m_hardfork->get_current_version();
+  bool found = false;
+
+  auto f = [&](uint64_t amount, const crypto::hash &tx_hash, uint64_t height, size_t index) {
+    if (found)
+      return false;
+    try {
+      output_data_t od = m_db->get_output_key(amount, index);
+      if (od.pubkey == stake_key)
+      {
+        if (is_tx_spendtime_unlocked(od.unlock_time, hf_version) &&
+            height + STAKE_MATURITY_BLOCKS <= current_height)
+        {
+          found = true;
+          return false;
+        }
+      }
+    } catch (...) { }
+    return true;
+  };
+
+  m_db->for_all_outputs(f);
+  return found;
 }
 //------------------------------------------------------------------
 void Blockchain::get_output_key_mask_unlocked(const uint64_t& amount, const uint64_t& index, crypto::public_key& key, rct::key& mask, bool& unlocked) const

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1463,6 +1463,18 @@ namespace cryptonote
     bool verify_stake_signature(const block& bl, const crypto::hash& id) const;
 
     /**
+     * @brief checks if the given public key has a mature stake
+     *
+     * Scans the output database for an output matching the key that is
+     * unlocked and at least STAKE_MATURITY_BLOCKS old.
+     *
+     * @param stake_key the staking public key to check
+     *
+     * @return true if a mature output is found
+     */
+    bool has_mature_unspent_stake(const crypto::public_key &stake_key) const;
+
+    /**
      * @brief reverts the blockchain to its previous state following a failed switch
      *
      * If Blockchain fails to switch to an alternate chain when it means


### PR DESCRIPTION
## Summary
- add staking constants
- validate that staking key has a mature stake in block verification
- expose helper `has_mature_unspent_stake`

## Testing
- `make -j1` *(fails: Submodule 'external/miniupnp' is not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_685e23a368cc8332a0c4a70e0f332a86