### PR TITLE
Add staking signature validation during block verification

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2366,6 +2366,13 @@ bool Blockchain::verify_stake_signature(const block& bl, const crypto::hash& id)
   return true;
 }
 
+//------------------------------------------------------------------
+bool Blockchain::validate_staking_signature(const block& bl, const crypto::hash& id) const
+{
+  LOG_PRINT_L3("Blockchain::" << __func__);
+  return verify_stake_signature(bl, id);
+}
+
 crypto::public_key Blockchain::get_output_key(uint64_t amount, uint64_t global_index) const
 {
   output_data_t data = m_db->get_output_key(amount, global_index);
@@ -4186,6 +4193,14 @@ leave:
       MERROR_VER("Block with id: " << id << std::endl << "does not have enough proof of work: " << proof_of_work << " at height " << blockchain_height << ", unexpected difficulty: " << current_diffic);
       bvc.m_verifivation_failed = true;
       bvc.m_bad_pow = true;
+      goto leave;
+    }
+
+    // validate stake signature when present
+    if (!validate_staking_signature(bl, id))
+    {
+      MERROR_VER("Block with id: " << id << " failed staking signature validation");
+      bvc.m_verifivation_failed = true;
       goto leave;
     }
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1469,9 +1469,22 @@ namespace cryptonote
      * @param bl the block containing the coinbase transaction
      * @param id the hash of the block
      *
-     * @return true if the signature is valid, false otherwise
+    * @return true if the signature is valid, false otherwise
      */
     bool verify_stake_signature(const block& bl, const crypto::hash& id) const;
+
+    /**
+     * @brief validates the proof-of-stake signature
+     *
+     * This wrapper currently forwards to @ref verify_stake_signature but
+     * exists so additional staking checks can be added independently.
+     *
+     * @param bl the block containing the coinbase transaction
+     * @param id the hash of the block
+     *
+     * @return true if the signature is valid, false otherwise
+     */
+    bool validate_staking_signature(const block& bl, const crypto::hash& id) const;
 
     /**
      * @brief reverts the blockchain to its previous state following a failed switch


### PR DESCRIPTION
## Summary
- introduce `validate_staking_signature` helper
- call the new function during block verification after PoW

## Testing
- `cmake -B build -S .` *(fails: Submodule 'external/miniupnp' is not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_685e2622258c8332a3d8f8f7d5fe5fae