### PR TITLE
Add staking signature validation wrapper

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2372,6 +2372,12 @@ bool Blockchain::verify_stake_signature(const block& bl, const crypto::hash& id)
   return true;
 }
 
+//------------------------------------------------------------------
+bool Blockchain::validate_staking_signature(const block& bl, const crypto::hash& id) const
+{
+  return verify_stake_signature(bl, id); // placeholder for future checks
+}
+
 crypto::public_key Blockchain::get_output_key(uint64_t amount, uint64_t global_index) const
 {
   output_data_t data = m_db->get_output_key(amount, global_index);
@@ -4225,7 +4231,7 @@ leave:
     }
 
     // verify stake signature when present
-    if (!verify_stake_signature(bl, id))
+    if (!validate_staking_signature(bl, id))
     {
       MERROR_VER("Block with id: " << id << " failed stake signature verification");
       bvc.m_verifivation_failed = true;

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1474,6 +1474,19 @@ namespace cryptonote
     bool verify_stake_signature(const block& bl, const crypto::hash& id) const;
 
     /**
+     * @brief validates the staking signature for a block
+     *
+     * This function wraps verify_stake_signature and allows for additional
+     * checks to be implemented in the future.
+     *
+     * @param bl the block to check
+     * @param id the hash of the block
+     *
+     * @return true if the staking signature is valid
+     */
+    bool validate_staking_signature(const block& bl, const crypto::hash& id) const;
+
+    /**
      * @brief checks if the given public key has a mature stake
      *
      * Scans the output database for an output matching the key that is


### PR DESCRIPTION
## Summary
- introduce `validate_staking_signature` declaration
- add wrapper implementation in blockchain.cpp
- use the new wrapper during block verification

## Testing
- `make -j2 debug-test` *(fails: Submodule 'external/miniupnp' is not up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_685e2cd9e864833292889d026da8d8b9